### PR TITLE
feat: 비교하기 모달 수정 및 비교함 페이지 구현

### DIFF
--- a/src/api/searchPlanFilter.js
+++ b/src/api/searchPlanFilter.js
@@ -1,0 +1,24 @@
+export const searchPlanFilter = async (min_fee, max_fee, network_type) => {
+  try {
+    const response = await fetch("http://3.35.51.214/api/search_plan_filter", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        min_fee: min_fee,
+        max_fee: max_fee,
+        network_type: network_type,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error("데이터를 가져오는 데 실패했습니다.");
+    }
+
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/app/(yogo)/chatBot/page.js
+++ b/src/app/(yogo)/chatBot/page.js
@@ -2,7 +2,6 @@
 import styles from "./styles/page.module.css";
 import { Input, Button } from "@nextui-org/react";
 import { Icon } from "@iconify/react";
-import SendButton from "@/components/send";
 
 export default function chatBot() {
   return (
@@ -13,7 +12,6 @@ export default function chatBot() {
           clearable
           contentRightStyling={false}
           placeholder="요금제에 관해 궁금한 점을 물어보세요!"
-          contentRight={<SendButton />}
         />
         {/* <Button isIconOnly variant="light" size="sm">
           <Icon icon="bi:send-fill" width={30} height={30} />

--- a/src/app/(yogo)/layout.js
+++ b/src/app/(yogo)/layout.js
@@ -51,7 +51,8 @@ export default function Layout({ children, modal }) {
         <NavbarContent justify="end">
           <NavbarItem>
             {/* 특정 경로(/yogoChange)에서만 아이콘 추가 */}
-            {pathname.startsWith("/yogoChange/") && (
+            {(pathname === "/yogoChange" ||
+              pathname.startsWith("/yogoChange/")) && (
               <Tooltip content="요금제 비교함">
                 <Button
                   isIconOnly

--- a/src/app/(yogo)/layout.js
+++ b/src/app/(yogo)/layout.js
@@ -51,7 +51,7 @@ export default function Layout({ children, modal }) {
         <NavbarContent justify="end">
           <NavbarItem>
             {/* 특정 경로(/yogoChange)에서만 아이콘 추가 */}
-            {pathname === "/yogoChange" && (
+            {pathname.startsWith("/yogoChange/") && (
               <Tooltip content="요금제 비교함">
                 <Button
                   isIconOnly

--- a/src/app/(yogo)/yogoChange/[id]/page.js
+++ b/src/app/(yogo)/yogoChange/[id]/page.js
@@ -7,6 +7,8 @@ import Loading from "@/components/loading/loading";
 import { Image, Button, Divider } from "@nextui-org/react";
 import { Icon } from "@iconify/react";
 import styles from "@/components/tab/styles/customTab.module.css";
+import CompareModal from "@/components/modal/compare_modal";
+import ChangeModal from "@/components/modal/change_modal";
 
 export default function PlanDetailPage() {
   const router = useRouter();
@@ -14,11 +16,11 @@ export default function PlanDetailPage() {
 
   useEffect(() => {
     console.log("zustand에 저장된 plan 데이터:", plan); // 상태 확인용 로그
-
-    if (!plan) {
-      <Loading />;
-    }
   }, [plan]);
+
+  if (!plan) {
+    return <Loading />;
+  }
 
   const ImageSrc = (mno) => {
     switch (mno) {
@@ -113,11 +115,16 @@ export default function PlanDetailPage() {
           <span>{plan.net}</span>
         </div>
 
-        <div>
+        <div className={styles.group}>
           <span style={{ color: "#01A69F" }} className={styles.boldText}>
             <span style={{ paddingRight: "5px" }}>월</span>
             {plan.feeString}원
           </span>
+
+          <div className={styles.buttons}>
+            <CompareModal className={styles.compareButton2} data={plan} />
+            <ChangeModal className={styles.selectButton2} />
+          </div>
         </div>
       </div>
 
@@ -165,18 +172,6 @@ export default function PlanDetailPage() {
             제공되는 혜택이 없습니다
           </div>
         )}
-      </div>
-
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          alignContent: "center",
-          alignItems: "center",
-        }}
-      >
-        <Button className={styles.compareButton2}>비교하기</Button>
-        <Button className={styles.selectButton2}>변경하기</Button>
       </div>
     </>
   );

--- a/src/app/(yogo)/yogoChange/[id]/page.js
+++ b/src/app/(yogo)/yogoChange/[id]/page.js
@@ -101,13 +101,13 @@ export default function PlanDetailPage() {
             <Icon icon="si:phone-fill" width={15} />
           </span>
           <span style={{ paddingRight: "10px" }}>
-            {plan.mobileMessage === 9999 ? "무제한" : plan.mobileMessage}
+            {plan.mobileVoice === 9999 ? "무제한" : plan.mobileVoice + "분"}
           </span>
           <span style={{ paddingRight: "5px" }}>
             <Icon icon="lets-icons:message-fill" width={15} />
           </span>
           <span style={{ paddingRight: "10px" }}>
-            {plan.mobileVoice === 9999 ? "무제한" : plan.mobileVoice}
+            {plan.mobileMessage === 9999 ? "무제한" : plan.mobileMessage + "건"}
           </span>
           <span style={{ paddingRight: "5px" }}>
             <Icon icon="fluent:cellular-data-1-20-filled" width={15} />

--- a/src/app/(yogo)/yogoCompare/page.js
+++ b/src/app/(yogo)/yogoCompare/page.js
@@ -62,14 +62,16 @@ export default function yogoCompare() {
                     {
                       title: "전화",
                       content:
-                        plan.mobileVoice === 9999 ? "무제한" : plan.mobileVoice,
+                        plan.mobileVoice === 9999
+                          ? "무제한"
+                          : plan.mobileVoice + "분",
                     },
                     {
                       title: "문자",
                       content:
                         plan.mobileMessage === 9999
                           ? "무제한"
-                          : plan.mobileMessage,
+                          : plan.mobileMessage + "건",
                     },
                     { title: "네트워크망", content: plan.net },
                   ].map((detail, index) => (

--- a/src/app/(yogo)/yogoCompare/page.js
+++ b/src/app/(yogo)/yogoCompare/page.js
@@ -1,8 +1,128 @@
+"use client";
+
+import { useCompareStore } from "@/stores/compareStore";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardBody, Divider, Button } from "@nextui-org/react";
+import { Icon } from "@iconify/react";
+import styles from "@/app/(yogo)/yogoCompare/styles/yogoCompare.module.css";
+import ChangeModal from "@/components/modal/change_modal";
+import Loading from "@/components/loading/loading";
+
 export default function yogoCompare() {
+  const router = useRouter();
+  const { plans, resetPlans } = useCompareStore();
+
+  useEffect(() => {
+    console.log("비교함에 담긴 데이터:", plans);
+  }, [plans]);
+
+  const handleBackClick = () => {
+    router.back();
+    resetPlans();
+  };
+
+  if (plans === null) {
+    return <Loading />;
+  }
+
   return (
-    <div>
-      <h1>타사 요금제 비교</h1>
+    <div className={styles.page}>
+      <div style={{ display: "flex", flexDirection: "row" }}>
+        <Button isIconOnly variant="light" size="sm" onClick={handleBackClick}>
+          <Icon
+            icon="weui:back-filled"
+            width={30}
+            height={30}
+            color="#979797"
+          />
+        </Button>
+        <p className={styles.title}>요금제를 비교해보세요</p>
+      </div>
+      <div className={styles.card_page}>
+        {plans.map((plan, idx) =>
+          plan ? ( // plan이 null이 아닐 때만 렌더링
+            <div
+              key={plan.id || `plan-${idx}`}
+              style={{ display: "flex", flexDirection: "column" }}
+            >
+              <Card className={styles.card1}>
+                <CardBody>
+                  <p className={styles.card_title}>선택한 요금제 {idx + 1}</p>
+                  <p className={styles.card_name}>{plan.name}</p>
+                </CardBody>
+              </Card>
+
+              <Card className={styles.card2}>
+                <CardBody>
+                  {[
+                    { title: "월정액", content: plan.feeString },
+                    { title: "데이터", content: plan.mobileDataStr || 0 },
+                    { title: "통신사", content: plan.mno },
+                    {
+                      title: "전화",
+                      content:
+                        plan.mobileVoice === 9999 ? "무제한" : plan.mobileVoice,
+                    },
+                    {
+                      title: "문자",
+                      content:
+                        plan.mobileMessage === 9999
+                          ? "무제한"
+                          : plan.mobileMessage,
+                    },
+                    { title: "네트워크망", content: plan.net },
+                  ].map((detail, index) => (
+                    <div key={`${plan.id || idx}-${index}`}>
+                      <p className={styles.card2_title}>{detail.title}</p>
+                      <p className={styles.card2_content}>{detail.content}</p>
+                      <Divider />
+                    </div>
+                  ))}
+                  <p className={styles.card2_title}>혜택</p>
+                  {plan.giftList && plan.giftList.length > 0 ? (
+                    <div>
+                      {plan.giftList.map((gift, num) => (
+                        <div
+                          className={styles.card2_content}
+                          key={plan.id || idx}
+                        >
+                          <p>혜택 {num + 1}.</p>
+                          <p>{gift.eventTitle}</p>
+                          <p>• {gift.description}</p>
+                          {gift.receiptDate && (
+                            <p style={{ marginBottom: "5px" }}>
+                              • 제공 시기: {gift.receiptDate}
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    // 혜택이 없을 때
+                    <div className={styles.card2_content}>
+                      제공되는 혜택이 없습니다
+                    </div>
+                  )}
+                </CardBody>
+              </Card>
+
+              <div style={{ marginLeft: "50px" }}>
+                <ChangeModal />
+              </div>
+            </div>
+          ) : (
+            // plan이 null일 경우 대체 콘텐츠 렌더링
+            <Card className={styles.card1} key={idx}>
+              <CardBody>
+                <p className={styles.card_name}>
+                  요금제가 선택되지 않았습니다.
+                </p>
+              </CardBody>
+            </Card>
+          )
+        )}
+      </div>
     </div>
   );
 }
-// 타사 요금제 비교

--- a/src/app/(yogo)/yogoCompare/styles/yogoCompare.module.css
+++ b/src/app/(yogo)/yogoCompare/styles/yogoCompare.module.css
@@ -1,0 +1,70 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  padding: 17px;
+}
+.title {
+  font-size: 20px;
+  font-weight: bold;
+  align-items: center;
+  align-content: center;
+}
+
+.card_page {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 20px;
+  gap: 5px;
+}
+
+.card1 {
+  width: 170px;
+  height: auto;
+  border-radius: 15px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.card_title {
+  font-size: 10px;
+  margin-bottom: 5px;
+}
+
+.card_name {
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.card2 {
+  width: 170px;
+  height: auto;
+  border-radius: 15px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.card2_title {
+  color: #01a69f;
+  font-size: 10px;
+  font-weight: bold;
+  margin-top: 3px;
+  margin-bottom: 3px;
+}
+
+.card2_content {
+  font-size: 13px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.button {
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}

--- a/src/components/dropdown/filter.js
+++ b/src/components/dropdown/filter.js
@@ -8,9 +8,11 @@ import {
 } from "@nextui-org/react";
 import { Icon } from "@iconify/react";
 import styles from "./styles/menu.module.css";
+import FilterModal from "../modal/filter_modal";
 
-export default function Filter({ onFilterChange }) {
+export default function Filter({ onFilterChange, onSearchChange }) {
   const [selected, setSelected] = useState(new Set(["전체"]));
+  const [filters, setFilters] = useState([]);
 
   const selectedValue = React.useMemo(
     () => Array.from(selected).join(", ").replaceAll("_", " "),
@@ -20,6 +22,15 @@ export default function Filter({ onFilterChange }) {
   const handleFilterChange = (keys) => {
     setSelected(keys);
     onFilterChange(Array.from(keys).join(", ")); // 부모 컴포넌트로 선택된 값 전달
+  };
+
+  // 필터 모달에서 받은 값을 처리하는 함수
+  const handleSearchChange = ({ minFee, maxFee, network }) => {
+    console.log("Filter에서 받은 값:", { minFee, maxFee, network });
+    setFilters({ minFee, maxFee, network });
+    if (onSearchChange) {
+      onSearchChange({ minFee, maxFee, network });
+    }
   };
 
   return (
@@ -49,10 +60,11 @@ export default function Filter({ onFilterChange }) {
 
       {/* 필터 2 */}
       <div style={{ paddingLeft: "10px" }}>
-        <Button auto light className={styles.filter}>
+        {/* <Button auto light className={styles.filter}>
           <Icon icon="rivet-icons:filter" className={styles.filterIcon} />
           필터
-        </Button>
+        </Button> */}
+        <FilterModal onSearchChange={handleSearchChange} />
       </div>
     </>
   );

--- a/src/components/modal/change_modal.js
+++ b/src/components/modal/change_modal.js
@@ -1,0 +1,44 @@
+"use client";
+import React, { useEffect, useRef, useState } from "react";
+import { Icon } from "@iconify/react";
+import "./styles/change_modal.css";
+import styles from "../tab/styles/customTab.module.css";
+
+function ChangeModal() {
+  const dialogRef = useRef(null);
+
+  const showModal = () => {
+    dialogRef.current?.showModal();
+  };
+
+  const closeModal = () => {
+    dialogRef.current?.close();
+  };
+
+  return (
+    <div>
+      <button onClick={showModal} className={styles.selectButton}>
+        변경하기
+      </button>
+
+      <dialog ref={dialogRef}>
+        <Icon
+          className="close"
+          onClick={closeModal}
+          icon="material-symbols-light:close"
+          width={20}
+          height={20}
+        />
+        <div className="change">
+          <Icon icon="la:check-circle" width={30} height={40} />
+          <div className="alert">요금제가 변경되었습니다.</div>
+          <button className="check" onClick={closeModal}>
+            확인
+          </button>
+        </div>
+      </dialog>
+    </div>
+  );
+}
+
+export default ChangeModal;

--- a/src/components/modal/compare_modal.js
+++ b/src/components/modal/compare_modal.js
@@ -1,0 +1,91 @@
+"use client";
+import React, { useRef } from "react";
+import { Icon } from "@iconify/react";
+import "./styles/compare_modal.css";
+import { useRouter } from "next/navigation";
+import { useCompareStore } from "@/stores/compareStore";
+import styles from "../tab/styles/customTab.module.css";
+
+function CompareModal({ data }) {
+  const router = useRouter();
+  const { plans, addPlan, removePlan } = useCompareStore();
+
+  const handleCompareClick = () => {
+    if (data !== null) {
+      addPlan(data);
+      showModal();
+    }
+  };
+
+  const handleConfirmation = () => {
+    const selectedCount = plans.filter((plan) => plan !== null).length;
+
+    if (selectedCount === 2) {
+      router.push("/yogoCompare");
+    } else {
+      closeModal();
+    }
+  };
+
+  const handleCancel = () => {
+    removePlan();
+    closeModal();
+  };
+
+  const dialogRef = useRef(null);
+
+  const showModal = () => {
+    dialogRef.current?.showModal();
+  };
+
+  const closeModal = () => {
+    dialogRef.current?.close();
+  };
+
+  return (
+    <div>
+      <button onClick={handleCompareClick} className={styles.compareButton}>
+        비교하기
+      </button>
+
+      <dialog ref={dialogRef} className={styles.dialog}>
+        <Icon
+          className="close"
+          onClick={handleCancel}
+          icon="material-symbols-light:close"
+          width={20}
+          height={20}
+        />
+        <div className="compare">
+          <Icon icon="material-symbols:download" width={30} height={40} />
+          <div className="alert">
+            {plans.filter((plan) => plan !== null).length === 2 ? (
+              <>
+                비교함에 담았어요. <br /> 비교함으로 이동할게요.
+              </>
+            ) : (
+              <>
+                비교함에 담았어요. <br />
+                비교할 요금제를 하나 더 담아주세요.
+              </>
+            )}
+          </div>
+          <div>
+            {" "}
+            {/* plans 배열에서 null이 아닌 값의 개수를 세어 표시 */}
+            {plans.filter((plan) => plan !== null).length === 2
+              ? "(2/2)"
+              : "(1/2)"}
+          </div>
+          <button className="check" onClick={handleConfirmation}>
+            {plans.filter((plan) => plan !== null).length === 2
+              ? "비교함"
+              : "확인"}
+          </button>
+        </div>
+      </dialog>
+    </div>
+  );
+}
+
+export default CompareModal;

--- a/src/components/modal/filter_modal.js
+++ b/src/components/modal/filter_modal.js
@@ -1,0 +1,154 @@
+"use client";
+import React, { useState, useRef } from "react";
+import "./styles/filter_modal.css";
+import { Button, Divider } from "@nextui-org/react";
+import Image from "next/image";
+import PriceSlider from "../slider/price_slider";
+import styles from "../dropdown/styles/menu.module.css";
+import { Icon } from "@iconify/react";
+
+function FilterModal({ onSearchChange }) {
+  const dialogRef = useRef(null);
+  const [isKTActive, setIsKTActive] = useState(false);
+  const [isSKTActive, setIsSKTActive] = useState(false);
+  const [isLGActive, setIsLGActive] = useState(false);
+  const [minFee, setMinFee] = useState(0);
+  const [maxFee, setMaxFee] = useState(70000);
+
+  // const onSearchChange = ({ minFee, maxFee, network }) => {
+  //   setLoading(true);
+  // };
+
+  const handleKTClick = () => {
+    setIsKTActive((prevState) => !prevState);
+  };
+
+  const handleSKTClick = () => {
+    setIsSKTActive((prevState) => !prevState);
+  };
+
+  const handleLGClick = () => {
+    setIsLGActive((prevState) => !prevState);
+  };
+
+  const showModal = () => {
+    dialogRef.current?.showModal();
+  };
+
+  const closeModal = () => {
+    setIsKTActive(false);
+    setIsSKTActive(false);
+    setIsLGActive(false);
+    setMinFee(0);
+    setMaxFee(70000);
+    dialogRef.current?.close();
+  };
+
+  const handleConfirm = () => {
+    const selectedNetWorks = [];
+
+    if (isKTActive) selectedNetWorks.push("KT");
+    if (isSKTActive) selectedNetWorks.push("SKT");
+    if (isLGActive) selectedNetWorks.push("LG");
+
+    if (onSearchChange) {
+      onSearchChange({
+        minFee,
+        maxFee,
+        network: selectedNetWorks,
+      });
+    }
+
+    console.log("min:", minFee);
+    console.log("max:", maxFee);
+    console.log("network:", selectedNetWorks);
+
+    dialogRef.current?.close();
+  };
+
+  return (
+    <div style={{ height: "auto" }}>
+      <Button auto light className={styles.filter} onClick={showModal}>
+        <Icon icon="rivet-icons:filter" className={styles.filterIcon} />
+        필터
+      </Button>
+
+      <dialog ref={dialogRef}>
+        <div className="question">어떤 요금제를 찾으시나요?</div>
+        <Divider className="divide" />
+        <PriceSlider
+          aria-label="Price Slider"
+          onChange={(min, max) => {
+            setMinFee(min);
+            setMaxFee(max);
+          }}
+        />
+
+        <div className="tel">통신사</div>
+        <div className="logos">
+          <button
+            aria-label="Network Selection Button1"
+            className="logo"
+            onClick={handleKTClick}
+            style={{
+              backgroundColor: !isKTActive ? "#f5f5f5" : "#86e8d1",
+            }}
+          >
+            <Image
+              className="logoImg"
+              src={"/images/kt_logo.png"}
+              alt="kt"
+              width={15}
+              height={15}
+            />
+            <span style={{ marginLeft: "-45px" }}>KT</span>
+          </button>
+          <button
+            aria-label="Network Selection Button2"
+            className="logo"
+            onClick={handleSKTClick}
+            style={{
+              backgroundColor: !isSKTActive ? "#f5f5f5" : "#86e8d1",
+            }}
+          >
+            <Image
+              className="logoImg"
+              src={"/images/skt_logo.png"}
+              alt="skt"
+              width={17}
+              height={17}
+            />
+            <span style={{ marginLeft: "-45px" }}>SKT</span>
+          </button>
+          <button
+            aria-label="Network Selection Button3"
+            className="logo"
+            onClick={handleLGClick}
+            style={{
+              backgroundColor: !isLGActive ? "#f5f5f5" : "#86e8d1",
+            }}
+          >
+            <Image
+              className="logoImg"
+              src={"/images/lgu_logo.png"}
+              alt="LG"
+              width={17}
+              height={17}
+            />
+            <span style={{ marginLeft: "-45px" }}>LG</span>
+          </button>
+        </div>
+        <div className="buttons">
+          <button className="cancel" onClick={closeModal}>
+            취소
+          </button>
+          <button className="ok" onClick={handleConfirm}>
+            완료
+          </button>
+        </div>
+      </dialog>
+    </div>
+  );
+}
+
+export default FilterModal;

--- a/src/components/modal/styles/change_modal.css
+++ b/src/components/modal/styles/change_modal.css
@@ -1,0 +1,38 @@
+dialog {
+  width: 300px;
+  height: 165px;
+  border-radius: 8px;
+}
+
+.close {
+  float: right;
+  margin-right: 10px;
+  margin-top: 10px;
+}
+
+.check {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  background-color: #e0f6f4;
+  border-radius: 8px;
+  width: 90px;
+  height: 27px;
+  font-size: 11px;
+  font-weight: 570;
+}
+
+.alert {
+  margin-top: 5px;
+  font-weight: 540;
+  text-align: center;
+}
+
+.change {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  column-gap: 5px;
+  margin-top: 30px;
+  text-align: center;
+}

--- a/src/components/modal/styles/compare_modal.css
+++ b/src/components/modal/styles/compare_modal.css
@@ -1,0 +1,38 @@
+.compare {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  column-gap: 5px;
+  margin-top: 30px;
+  text-align: center;
+}
+
+.close {
+  float: right;
+  margin-right: 10px;
+  margin-top: 10px;
+}
+
+.dialog {
+  width: 300px;
+  height: 205px;
+  border-radius: 8px;
+}
+
+.check {
+  margin-top: 15px;
+  margin-bottom: 20px;
+  background-color: #e0f6f4;
+  border-radius: 8px;
+  width: 90px;
+  height: 27px;
+  font-size: 11px;
+  font-weight: 570;
+}
+
+.alert {
+  margin-top: 5px;
+  font-weight: 540;
+  text-align: center;
+}

--- a/src/components/modal/styles/filter_modal.css
+++ b/src/components/modal/styles/filter_modal.css
@@ -1,0 +1,68 @@
+dialog {
+  width: 350px;
+  height: 400px;
+  border-radius: 8px;
+  padding: 15px;
+}
+
+.question {
+  margin-bottom: 10px;
+  font-size: medium;
+  font-weight: 550;
+}
+
+.logos {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
+  justify-content: center;
+}
+
+.tel {
+  font-weight: 500;
+  font-size: 16px;
+  margin-top: 30px;
+  margin-bottom: 5px;
+}
+
+.logo {
+  width: 300px;
+  height: 36px;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.logoImg {
+  float: left;
+  margin: 6px 15px;
+}
+
+.cancel {
+  width: 75px;
+  height: 30px;
+  border-radius: 8px;
+  background-color: #f5f5f5;
+  text-align: center;
+  font-size: 14px;
+}
+
+.ok {
+  width: 75px;
+  height: 30px;
+  border-radius: 8px;
+  background-color: #86e8d1;
+  text-align: center;
+  font-size: 14px;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: row;
+  column-gap: 10px;
+  justify-content: center;
+  margin-top: 30px;
+}
+
+.divide {
+  margin-bottom: 15px;
+}

--- a/src/components/slider/price_slider.js
+++ b/src/components/slider/price_slider.js
@@ -1,0 +1,62 @@
+import { Slider } from "@nextui-org/react";
+import { useState } from "react";
+
+export default function PriceSlider({ onChange }) {
+  const [values, setValues] = useState([0, 70000]);
+
+  const handleChange = (newValues) => {
+    setValues(newValues);
+    onChange(newValues[0], newValues[1]);
+  };
+
+  return (
+    <Slider
+      label="요금제 범위"
+      step={10000}
+      maxValue={70000}
+      minValue={0}
+      defaultValue={[0, 70000]}
+      value={values}
+      onChange={handleChange}
+      showSteps={true}
+      showTooltip={true}
+      showOutline={true}
+      disableThumbScale={true}
+      formatOptions={{ style: "currency", currency: "KRW" }}
+      tooltipValueFormatOptions={{
+        style: "currency",
+        currency: "KRW",
+        maximumFractionDigits: 0,
+      }}
+      classNames={{
+        base: "max-w-[320px]",
+        filler: "bg-[#E0F6F4]",
+        labelWrapper: "mb-3",
+        label: "font-medium text-default-700 text-medium",
+        value: "font-medium text-default-500 text-small",
+        thumb: [
+          "transition-size",
+          "bg-[#0FE3B1]",
+          "data-[dragging=true]:shadow-lg data-[dragging=true]:shadow-black/20",
+          "w-4 h-4",
+        ],
+        step: "data-[in-range=true]:bg-black/30 dark:data-[in-range=true]:bg-white/50",
+      }}
+      tooltipProps={{
+        offset: 10,
+        placement: "bottom",
+        classNames: {
+          base: [
+            // arrow color
+            "before:bg-gradient-to-r before:from-secondary-400 before:to-primary-500",
+          ],
+          content: [
+            "py-2 shadow-xl",
+            "text-white bg-gradient-to-r from-secondary-400 to-primary-500",
+          ],
+        },
+      }}
+      showValue={true}
+    />
+  );
+}

--- a/src/components/slider/styles/brand_slider.css
+++ b/src/components/slider/styles/brand_slider.css
@@ -1,10 +1,9 @@
 .slide {
   position: relative;
-  overflow: hidden;
 }
 
 .background {
-  background-image: url('../../../../public/images/brand-slider/brand0.png');
+  background-image: url("../../../../public/images/brand-slider/brand0.png");
   background-repeat: no-repeat;
   background-size: cover;
   width: 390px;
@@ -18,5 +17,4 @@
 .sliderWrapper {
   position: relative;
   top: 30px;
-  z-index: 2;
 }

--- a/src/components/tab/customTabCard.js
+++ b/src/components/tab/customTabCard.js
@@ -89,14 +89,16 @@ export default function CustomTabCard({ data }) {
                 <div className={styles.info}>
                   <span style={{ paddingRight: "5px" }}>통화</span>
                   <span style={{ paddingRight: "10px" }}>
-                    {plan.mobileMessage === 9999
+                    {plan.mobileVoice === 9999
                       ? "무제한"
-                      : plan.mobileMessage}
+                      : plan.mobileVoice + "분"}
                   </span>
                   <span style={{ paddingRight: "10px" }}>|</span>
                   <p style={{ paddingRight: "5px" }}>문자</p>
                   <span style={{ paddingRight: "10px" }}>
-                    {plan.mobileVoice === 9999 ? "무제한" : plan.mobileVoice}
+                    {plan.mobileMessage === 9999
+                      ? "무제한"
+                      : plan.mobileMessage + "건"}
                   </span>
                   <span style={{ paddingRight: "10px" }}>|</span>
                   <span>{plan.net}</span>

--- a/src/components/tab/customTabCard.js
+++ b/src/components/tab/customTabCard.js
@@ -4,13 +4,14 @@ import {
   Card,
   CardBody,
   Image,
-  Button,
   Divider,
   Accordion,
   AccordionItem,
 } from "@nextui-org/react";
 import { useRouter } from "next/navigation";
 import styles from "@/components/tab/styles/customTab.module.css";
+import CompareModal from "../modal/compare_modal";
+import ChangeModal from "../modal/change_modal";
 import { usePlanStore } from "@/stores/planStore";
 
 export default function CustomTabCard({ data }) {
@@ -107,9 +108,11 @@ export default function CustomTabCard({ data }) {
                   <span style={{ paddingRight: "5px" }}>월</span>
                   {plan.feeString}원
                 </span>
-
-                <Button className={styles.compareButton}>비교하기</Button>
-                <Button className={styles.selectButton}>변경하기</Button>
+                {/* 버튼 모달 추가 */}
+                <div className={styles.buttons}>
+                  <CompareModal data={plan} />
+                  <ChangeModal />
+                </div>
               </div>
 
               <Divider />

--- a/src/components/tab/customTabCard.js
+++ b/src/components/tab/customTabCard.js
@@ -57,7 +57,7 @@ export default function CustomTabCard({ data }) {
 
   return (
     <>
-      {data.planMetas.map((plan, idx) => (
+      {data.plans.map((plan, idx) => (
         <Card className={styles.card} key={plan.id || idx}>
           <CardBody>
             <div>

--- a/src/components/tab/styles/customTab.module.css
+++ b/src/components/tab/styles/customTab.module.css
@@ -108,26 +108,28 @@
   color: #01a69f;
   margin-left: auto;
 }
-
 .compareButton {
-  width: 20px;
-  height: 20px;
-  font-size: 12px;
+  width: 65px;
+  height: 23px;
+  font-size: 11px;
+  font-weight: bold;
   background-color: white;
   border: 1px solid #979797;
   margin-top: 25px;
   margin-right: 5px;
   margin-left: 70px;
+  border-radius: 15px;
 }
 
 .selectButton {
-  width: 20px;
-  height: 20px;
-  font-size: 12px;
+  width: 65px;
+  height: 23px;
+  font-size: 11px;
   font-weight: bold;
   color: white;
   background-color: #32c5bf;
   margin-top: 25px;
+  border-radius: 15px;
 }
 
 .compareButton2 {
@@ -170,4 +172,16 @@
   color: #979797;
   font-weight: medium;
   margin-bottom: 5px;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: row;
+  column-gap: 3px;
+  transform: translateX(25px);
+}
+
+.group {
+  display: flex;
+  flex-direction: row;
 }

--- a/src/stores/compareStore.js
+++ b/src/stores/compareStore.js
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const useCompareStore = create(
+  persist(
+    (set) => ({
+      plans: [null, null],
+      addPlan: (plan) =>
+        set((state) => {
+          // plans 배열에서 첫 번째 비어 있는 슬롯(null)을 찾습니다.
+          const index = state.plans.findIndex((p) => p === null);
+          if (index !== -1) {
+            const updatedPlans = [...state.plans];
+            updatedPlans[index] = plan;
+            return { plans: updatedPlans };
+          }
+          return state;
+        }),
+      removePlan: () =>
+        set((state) => {
+          const updatedPlans = [...state.plans];
+          // 마지막으로 채워진 요소를 제거합니다.
+          const lastFilledIndex = updatedPlans.lastIndexOf(
+            updatedPlans.find((p) => p !== null)
+          );
+          if (lastFilledIndex !== -1) {
+            updatedPlans[lastFilledIndex] = null;
+          }
+          return { plans: updatedPlans };
+        }),
+      resetPlans: () =>
+        set(() => ({
+          plans: [null, null],
+        })),
+    }),
+    {
+      name: "compare-storage",
+    }
+  )
+);


### PR DESCRIPTION
1. 비교함에 들어가는 데이터 관리 -> zustand 상태 관리 라이브러리 이용 (src/stores/compareStore.js 참고)
(0개 데이터가 담겼을 때)
<img width="1400" alt="스크린샷 2024-10-28 오후 10 53 42" src="https://github.com/user-attachments/assets/99ab3303-7e49-4bfb-80ca-df5c5aba2563">
(1개 데이터가 담겼을 때)
<img width="1400" alt="스크린샷 2024-10-28 오후 10 56 11" src="https://github.com/user-attachments/assets/eb5a4d47-19fc-4765-ba6a-1aaec075365a">
(2개 데이터가 담겼을 때)
<img width="1400" alt="스크린샷 2024-10-28 오후 10 57 04" src="https://github.com/user-attachments/assets/196ec81b-3606-4572-8fff-e452caf4e9ce">

2. 비교함 페이지 구현: 뒤로 가기 버튼 누를 시 storage에 저장된 데이터 reset
<img width="1400" alt="스크린샷 2024-10-28 오후 10 57 58" src="https://github.com/user-attachments/assets/4aedb14a-36ce-41d9-a3a1-2118418d9bd0">

3. 두번째 필터 모달 연결 문제 해결
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/af6a3138-053b-44a8-b03a-2412d75be727">
4. 상단바 요금제 비교함 show 여부 경로 수정